### PR TITLE
refactor(cli): Various refactoring to improve code maintainability

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -151,12 +151,12 @@ _load_indicators() {
     done < <(yaml_system_path_entries "$indicators")
 
     _load_yaml_array malicious_sha256_hashes yaml_object_pair "$indicators" hashes sha256 description "|"
-    _load_yaml_array malicious_ioc_strings   yaml_object_field "$indicators" ioc_strings value
-    _load_yaml_array malicious_filenames     yaml_object_field "$indicators" filenames name
-    _load_yaml_array scannable_extensions    yaml_plain_list "$indicators" scannable_extensions
-    _load_yaml_array malicious_ips           yaml_ip_entries "$indicators"
-    _load_yaml_array malicious_urls          yaml_url_entries "$indicators"
-    _load_yaml_array malicious_git_commits   yaml_git_commit_entries "$indicators"
+    _load_yaml_array malicious_ioc_strings yaml_object_field "$indicators" ioc_strings value
+    _load_yaml_array malicious_filenames yaml_object_field "$indicators" filenames name
+    _load_yaml_array scannable_extensions yaml_plain_list "$indicators" scannable_extensions
+    _load_yaml_array malicious_ips yaml_ip_entries "$indicators"
+    _load_yaml_array malicious_urls yaml_url_entries "$indicators"
+    _load_yaml_array malicious_git_commits yaml_git_commit_entries "$indicators"
 
     while IFS= read -r line; do affected_packages+=("$line"); done \
         < <(yaml_package_entries "$indicators"; yaml_package_range_entries "$indicators")

--- a/scan.sh
+++ b/scan.sh
@@ -34,6 +34,7 @@ source "$SRC_DIR/scanner.sh"
 # shellcheck source=src/yaml_loader.sh
 source "$SRC_DIR/yaml_loader.sh"
 
+# Hits files — created by _run_scan, referenced by the EXIT trap.
 system_hits_file=""
 hash_hits_file=""
 string_hits_file=""
@@ -94,16 +95,32 @@ EOF
     exit 0
 }
 
-main() {
+# Usage: _load_yaml_array <array_name> <command> [args...]
+# Appends one entry per output line from <command> into the named array.
+# Uses eval to modify the caller's array by name — safe because array_name is
+# always a fixed identifier within this script, never derived from user input.
+_load_yaml_array() {
+    local _name="$1"; shift
+    local _line
+    while IFS= read -r _line; do
+        # shellcheck disable=SC2294
+        eval "${_name}+=(\"\$_line\")"
+    done < <("$@")
+}
+
+# Parses command-line arguments.
+# Writes to caller's scope: cve_dir, json_mode, output_file, scan_root
+_parse_args() {
     if [ $# -eq 0 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
         usage
     fi
 
-    local cve_dir
     cve_dir="$(cd "$1" && pwd)" || { printf 'Error: directory not found: %s\n' "$1" >&2; exit 2; }
     shift
 
-    local output_file="" json_mode=false scan_root=""
+    json_mode=false
+    output_file=""
+    scan_root=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -114,27 +131,16 @@ main() {
             *) scan_root="$1"; shift ;;
         esac
     done
+}
 
-    local indicators="$cve_dir/indicators.yaml"
-    if [ ! -f "$indicators" ]; then
-        printf 'Error: no indicators.yaml found in %s\n' "$cve_dir" >&2
-        printf '\n' >&2
-        local available
-        available="$(list_available_cves)"
-        if [ -n "$available" ]; then
-            printf 'Available scanners:\n' >&2
-            printf '  %s\n' "$available" >&2
-        fi
-        exit 2
-    fi
+# Loads all indicator data from <indicators_file>.
+# Writes to caller's scope: malicious_system_paths, malicious_sha256_hashes,
+#   malicious_ioc_strings, malicious_filenames, scannable_extensions,
+#   malicious_ips, malicious_urls, malicious_git_commits, affected_packages,
+#   cve_id_val, title
+_load_indicators() {
+    local indicators="$1"
 
-    scan_root="${scan_root:-.}"
-    scan_root="$(cd "$scan_root" && pwd)"
-
-    local current_platform
-    current_platform="$(detect_platform)"
-
-    local malicious_system_paths=()
     local entry path platforms
     while IFS= read -r entry; do
         path="${entry%%|*}"
@@ -144,41 +150,27 @@ main() {
         fi
     done < <(yaml_system_path_entries "$indicators")
 
-    local malicious_sha256_hashes=()
-    while IFS= read -r line; do malicious_sha256_hashes+=("$line"); done \
-        < <(yaml_object_pair "$indicators" hashes sha256 description "|")
+    _load_yaml_array malicious_sha256_hashes yaml_object_pair "$indicators" hashes sha256 description "|"
+    _load_yaml_array malicious_ioc_strings   yaml_object_field "$indicators" ioc_strings value
+    _load_yaml_array malicious_filenames     yaml_object_field "$indicators" filenames name
+    _load_yaml_array scannable_extensions    yaml_plain_list "$indicators" scannable_extensions
+    _load_yaml_array malicious_ips           yaml_ip_entries "$indicators"
+    _load_yaml_array malicious_urls          yaml_url_entries "$indicators"
+    _load_yaml_array malicious_git_commits   yaml_git_commit_entries "$indicators"
 
-    local malicious_ioc_strings=()
-    while IFS= read -r line; do malicious_ioc_strings+=("$line"); done \
-        < <(yaml_object_field "$indicators" ioc_strings value)
-
-    local malicious_filenames=()
-    while IFS= read -r line; do malicious_filenames+=("$line"); done \
-        < <(yaml_object_field "$indicators" filenames name)
-
-    local scannable_extensions=()
-    while IFS= read -r line; do scannable_extensions+=("$line"); done \
-        < <(yaml_plain_list "$indicators" scannable_extensions)
-
-    local malicious_ips=()
-    while IFS= read -r line; do malicious_ips+=("$line"); done \
-        < <(yaml_ip_entries "$indicators")
-
-    local malicious_urls=()
-    while IFS= read -r line; do malicious_urls+=("$line"); done \
-        < <(yaml_url_entries "$indicators")
-
-    local malicious_git_commits=()
-    while IFS= read -r line; do malicious_git_commits+=("$line"); done \
-        < <(yaml_git_commit_entries "$indicators")
-
-    local affected_packages=()
     while IFS= read -r line; do affected_packages+=("$line"); done \
         < <(yaml_package_entries "$indicators"; yaml_package_range_entries "$indicators")
 
-    local cve_id_val title
     cve_id_val="$(yaml_scalar "$indicators" cve)"
     title="$(yaml_scalar "$indicators" title)"
+}
+
+# Creates hits temp files, runs the full scan, and registers EXIT cleanup.
+# Args: <scan_root> <exclude_path>
+# Writes to caller's scope: total_hits
+# Writes to script-level globals: *_hits_file (needed for EXIT trap)
+_run_scan() {
+    local scan_root="$1" exclude_path="$2"
 
     system_hits_file="$(mktemp)"
     hash_hits_file="$(mktemp)"
@@ -189,11 +181,6 @@ main() {
     git_commit_hits_file="$(mktemp)"
 
     trap 'rm -f "$system_hits_file" "$hash_hits_file" "$string_hits_file" "$package_hits_file" "$postinstall_hits_file" "$network_ioc_hits_file" "$git_commit_hits_file"' EXIT
-
-    local exclude_path=""
-    case "$REPO_ROOT" in
-        "$scan_root"|"$scan_root/"*) exclude_path="$REPO_ROOT" ;;
-    esac
 
     SCAN_START_TIME=$(date +%s)
     scan_directory "$scan_root" \
@@ -214,7 +201,6 @@ main() {
 
     clear_progress
 
-    local total_hits
     total_hits=$(( \
         $(count_hits "$system_hits_file") + \
         $(count_hits "$hash_hits_file") + \
@@ -224,8 +210,14 @@ main() {
         $(count_hits "$network_ioc_hits_file") + \
         $(count_hits "$git_commit_hits_file") \
     ))
+}
 
+# Formats scan results and writes to stdout or $output_file.
+# Args: <scan_root>
+_emit_output() {
+    local scan_root="$1"
     local output
+
     if $json_mode; then
         output="$(format_hits_as_json \
             "$system_hits_file" "$hash_hits_file" "$string_hits_file" \
@@ -253,7 +245,51 @@ main() {
     else
         printf '%s\n' "$output"
     fi
+}
 
+main() {
+    local cve_dir json_mode output_file scan_root
+    _parse_args "$@"
+
+    local indicators="$cve_dir/indicators.yaml"
+    if [ ! -f "$indicators" ]; then
+        printf 'Error: no indicators.yaml found in %s\n' "$cve_dir" >&2
+        printf '\n' >&2
+        local available
+        available="$(list_available_cves)"
+        if [ -n "$available" ]; then
+            printf 'Available scanners:\n' >&2
+            printf '  %s\n' "$available" >&2
+        fi
+        exit 2
+    fi
+
+    scan_root="${scan_root:-.}"
+    scan_root="$(cd "$scan_root" && pwd)"
+
+    local current_platform
+    current_platform="$(detect_platform)"
+
+    local malicious_system_paths=()
+    local malicious_sha256_hashes=()
+    local malicious_ioc_strings=()
+    local malicious_filenames=()
+    local scannable_extensions=()
+    local malicious_ips=()
+    local malicious_urls=()
+    local malicious_git_commits=()
+    local affected_packages=()
+    local cve_id_val title
+    _load_indicators "$indicators"
+
+    local exclude_path=""
+    case "$REPO_ROOT" in
+        "$scan_root"|"$scan_root/"*) exclude_path="$REPO_ROOT" ;;
+    esac
+
+    local total_hits=0
+    _run_scan "$scan_root" "$exclude_path"
+    _emit_output "$scan_root"
     [ "$total_hits" -eq 0 ]
 }
 

--- a/scan.sh
+++ b/scan.sh
@@ -44,9 +44,9 @@ network_ioc_hits_file=""
 git_commit_hits_file=""
 
 GREEN=""
-RESET=""
 if [ -t 1 ]; then
     GREEN='\033[0;32m'
+    RED='\033[0;31m'
     RESET='\033[0m'
 fi
 

--- a/src/output.sh
+++ b/src/output.sh
@@ -131,12 +131,12 @@ format_hits_as_json() {
     printf '  "hits": {\n'
 
     _JSON_FIRST_CATEGORY=true
-    _emit_json_category "system_artifacts"   "$system_hits_file"      "path,description"
-    _emit_json_category "file_hashes"        "$hash_hits_file"        "path,sha256,description"
-    _emit_json_category "ioc_strings"        "$string_hits_file"      "path,ioc"
-    _emit_json_category "vulnerable_packages" "$package_hits_file"    "path,package,description"
-    _emit_json_category "postinstall_hooks"  "$postinstall_hits_file" "path,indicator,description"
-    _emit_json_category "network_iocs"       "$network_ioc_hits_file" "path,value,description"
+    _emit_json_category "system_artifacts" "$system_hits_file" "path,description"
+    _emit_json_category "file_hashes" "$hash_hits_file" "path,sha256,description"
+    _emit_json_category "ioc_strings" "$string_hits_file" "path,ioc"
+    _emit_json_category "vulnerable_packages" "$package_hits_file" "path,package,description"
+    _emit_json_category "postinstall_hooks" "$postinstall_hits_file" "path,indicator,description"
+    _emit_json_category "network_iocs" "$network_ioc_hits_file" "path,value,description"
     [ -n "$git_commit_hits_file" ] && _emit_json_category "git_commits" "$git_commit_hits_file" "path,sha,description"
 
     printf '\n  }\n}\n'

--- a/src/output.sh
+++ b/src/output.sh
@@ -76,6 +76,40 @@ format_hits_as_text() {
     fi
 }
 
+# Module-level flag reset by format_hits_as_json before emitting categories.
+_JSON_FIRST_CATEGORY=true
+
+# Usage: _emit_json_category <category_name> <hits_file> <comma_separated_field_names>
+_emit_json_category() {
+    local category_name="$1"
+    local hits_file="$2"
+    local field_names="$3"
+    [ -s "$hits_file" ] || return 0
+
+    $_JSON_FIRST_CATEGORY || printf ',\n'
+    _JSON_FIRST_CATEGORY=false
+    printf '    "%s": [\n' "$category_name"
+    local first_item=true
+    while IFS='|' read -r line; do
+        $first_item || printf ',\n'
+        first_item=false
+        local fields_json=""
+        local field_index=1
+        local old_ifs="$IFS"
+        IFS=','
+        for field_name in $field_names; do
+            local field_val
+            field_val="$(printf '%s' "$line" | cut -d'|' -f"$field_index")"
+            fields_json="${fields_json}\"$(json_escape "$field_name")\": \"$(json_escape "$field_val")\","
+            field_index=$(( field_index + 1 ))
+        done
+        IFS="$old_ifs"
+        fields_json="${fields_json%,}"
+        printf '      {%s}' "$fields_json"
+    done < "$hits_file"
+    printf '\n    ]'
+}
+
 format_hits_as_json() {
     local system_hits_file="$1"
     local hash_hits_file="$2"
@@ -96,45 +130,14 @@ format_hits_as_json() {
     printf '  "total_hits": %d,\n' "$total_hits"
     printf '  "hits": {\n'
 
-    local first_category=true
-
-    emit_json_category() {
-        local category_name="$1"
-        local hits_file="$2"
-        local field_names="$3"
-        if [ -s "$hits_file" ]; then
-            $first_category || printf ',\n'
-            first_category=false
-            printf '    "%s": [\n' "$category_name"
-            local first_item=true
-            while IFS='|' read -r line; do
-                $first_item || printf ',\n'
-                first_item=false
-                local fields_json=""
-                local field_index=1
-                local old_ifs="$IFS"
-                IFS=','
-                for field_name in $field_names; do
-                    local field_val
-                    field_val="$(printf '%s' "$line" | cut -d'|' -f"$field_index")"
-                    fields_json="${fields_json}\"$(json_escape "$field_name")\": \"$(json_escape "$field_val")\","
-                    field_index=$(( field_index + 1 ))
-                done
-                IFS="$old_ifs"
-                fields_json="${fields_json%,}"
-                printf '      {%s}' "$fields_json"
-            done < "$hits_file"
-            printf '\n    ]'
-        fi
-    }
-
-    emit_json_category "system_artifacts" "$system_hits_file" "path,description"
-    emit_json_category "file_hashes" "$hash_hits_file" "path,sha256,description"
-    emit_json_category "ioc_strings" "$string_hits_file" "path,ioc"
-    emit_json_category "vulnerable_packages" "$package_hits_file" "path,package,description"
-    emit_json_category "postinstall_hooks" "$postinstall_hits_file" "path,indicator,description"
-    emit_json_category "network_iocs" "$network_ioc_hits_file" "path,value,description"
-    [ -n "$git_commit_hits_file" ] && emit_json_category "git_commits" "$git_commit_hits_file" "path,sha,description"
+    _JSON_FIRST_CATEGORY=true
+    _emit_json_category "system_artifacts"   "$system_hits_file"      "path,description"
+    _emit_json_category "file_hashes"        "$hash_hits_file"        "path,sha256,description"
+    _emit_json_category "ioc_strings"        "$string_hits_file"      "path,ioc"
+    _emit_json_category "vulnerable_packages" "$package_hits_file"    "path,package,description"
+    _emit_json_category "postinstall_hooks"  "$postinstall_hits_file" "path,indicator,description"
+    _emit_json_category "network_iocs"       "$network_ioc_hits_file" "path,value,description"
+    [ -n "$git_commit_hits_file" ] && _emit_json_category "git_commits" "$git_commit_hits_file" "path,sha,description"
 
     printf '\n  }\n}\n'
 }

--- a/src/package_check.sh
+++ b/src/package_check.sh
@@ -259,20 +259,6 @@ check_composer_lock() {
     done
 }
 
-check_requirements_txt() {
-    local filepath="$1"
-    local package_hits_file="$2"
-    # Placeholder — no Python packages affected; override in scanner if needed
-    return 0
-}
-
-check_github_actions() {
-    local filepath="$1"
-    local postinstall_hits_file="$2"
-    # Placeholder — no GitHub Actions checks for this CVE; override in scanner if needed
-    return 0
-}
-
 check_pipfile() {
     local filepath="$1" package_hits_file="$2"
     shift 2
@@ -422,12 +408,6 @@ check_manifests() {
             ;;
         Cargo.lock)
             check_cargo_lock "$filepath" "$package_hits_file" "$postinstall_hits_file" "$@"
-            ;;
-        requirements*.txt)
-            check_requirements_txt "$filepath" "$package_hits_file"
-            ;;
-        *.yml|*.yaml)
-            check_github_actions "$filepath" "$postinstall_hits_file" "$@"
             ;;
     esac
 }

--- a/src/package_check.sh
+++ b/src/package_check.sh
@@ -30,14 +30,13 @@ _record_package_hits() {
     done
 }
 
-# Usage: check_package_json <filepath> <package_hits_file> <postinstall_hits_file> <affected_package_entry>...
+# Usage: check_package_json <filepath> <package_hits_file> <affected_package_entry>...
 #
 # Each affected_package_entry has the form "package-name|version1 version2 ..."
 check_package_json() {
     local filepath="$1"
     local package_hits_file="$2"
-    local postinstall_hits_file="$3"
-    shift 3
+    shift 2
 
     local pkg_name installed_version
     pkg_name="$(grep -m1 '"name"' "$filepath" | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')" || true
@@ -54,18 +53,23 @@ check_package_json() {
             _record_package_hits "$filepath" "$affected_pkg" "$installed_version" "$package_hits_file" $malicious_versions
         fi
     done
+}
 
-    if grep -q '"postinstall"' "$filepath" 2>/dev/null; then
-        local postinstall_value
-        postinstall_value="$(grep -A1 '"postinstall"' "$filepath" | tail -1)" || true
-        local suspicious_string
-        for suspicious_string in "node-gyp.dll" "crashreporter.dll" "rundll32" "install.js" "logDiskSpace" "child_process"; do
-            if printf '%s' "$postinstall_value" | grep -qF "$suspicious_string" 2>/dev/null; then
-                printf '%s|%s|suspicious postinstall hook referencing: %s\n' \
-                    "$filepath" "$suspicious_string" "$suspicious_string" >> "$postinstall_hits_file"
-            fi
-        done
-    fi
+# Usage: check_postinstall_hooks <filepath> <postinstall_hits_file>
+check_postinstall_hooks() {
+    local filepath="$1" postinstall_hits_file="$2"
+
+    grep -q '"postinstall"' "$filepath" 2>/dev/null || return 0
+
+    local postinstall_value
+    postinstall_value="$(grep -A1 '"postinstall"' "$filepath" | tail -1)" || true
+    local suspicious_string
+    for suspicious_string in "node-gyp.dll" "crashreporter.dll" "rundll32" "install.js" "logDiskSpace" "child_process"; do
+        if printf '%s' "$postinstall_value" | grep -qF "$suspicious_string" 2>/dev/null; then
+            printf '%s|%s|suspicious postinstall hook referencing: %s\n' \
+                "$filepath" "$suspicious_string" "$suspicious_string" >> "$postinstall_hits_file"
+        fi
+    done
 }
 
 # Usage: check_package_lock_json <filepath> <package_hits_file> <postinstall_hits_file> <affected_package_entry>...
@@ -365,7 +369,8 @@ check_manifests() {
     shift 4
     case "$filename" in
         package.json)
-            check_package_json "$filepath" "$package_hits_file" "$postinstall_hits_file" "$@"
+            check_package_json "$filepath" "$package_hits_file" "$@"
+            check_postinstall_hooks "$filepath" "$postinstall_hits_file"
             ;;
         package-lock.json|npm-shrinkwrap.json)
             check_package_lock_json "$filepath" "$package_hits_file" "$postinstall_hits_file" "$@"

--- a/tests/package_check.bats
+++ b/tests/package_check.bats
@@ -24,7 +24,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "eslint-config-prettier" "8.10.1"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "eslint-config-prettier|8.10.1 9.1.1"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
@@ -35,7 +35,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "eslint-config-prettier" "8.9.0"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "eslint-config-prettier|8.10.1 9.1.1"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
@@ -45,7 +45,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "some-other-package" "8.10.1"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "eslint-config-prettier|8.10.1"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
@@ -55,7 +55,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "synckit" "0.11.9"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "eslint-config-prettier|8.10.1" \
         "synckit|0.11.9"
     rm -f "$f"
@@ -67,7 +67,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     printf '{"dependencies": {}}\n' > "$f"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "eslint-config-prettier|8.10.1"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
@@ -149,7 +149,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "next" "15.0.0"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "next|15.0.0,15.0.5"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
@@ -160,7 +160,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "next" "15.0.3"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "next|15.0.0,15.0.5"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
@@ -171,7 +171,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "next" "15.0.5"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "next|15.0.0,15.0.5"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
@@ -181,7 +181,7 @@ write_package_json() {
     local f
     f="$(mktemp)"
     write_package_json "$f" "next" "14.9.9"
-    check_package_json "$f" "$pkg_hits" "$post_hits" \
+    check_package_json "$f" "$pkg_hits" \
         "next|15.0.0,15.0.5"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]

--- a/tests/package_check.bats
+++ b/tests/package_check.bats
@@ -73,45 +73,34 @@ write_package_json() {
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
-# --- suspicious postinstall hooks ---
+# --- check_postinstall_hooks ---
 
-@test "check_package_json: records hit for suspicious postinstall hook" {
+@test "check_postinstall_hooks: records hit for suspicious postinstall hook" {
     local f
     f="$(mktemp)"
     printf '{"name":"pkg","version":"1.0.0","scripts":{"postinstall":"node node-gyp.dll"}}\n' > "$f"
-    check_package_json "$f" "$pkg_hits" "$post_hits"
+    check_postinstall_hooks "$f" "$post_hits"
     rm -f "$f"
     [ "$(wc -l < "$post_hits")" -ge 1 ]
     grep -q "node-gyp.dll" "$post_hits"
 }
 
-@test "check_package_json: no postinstall hit for clean scripts" {
+@test "check_postinstall_hooks: no hit for clean scripts" {
     local f
     f="$(mktemp)"
     printf '{"name":"pkg","version":"1.0.0","scripts":{"postinstall":"node setup.js"}}\n' > "$f"
-    check_package_json "$f" "$pkg_hits" "$post_hits"
+    check_postinstall_hooks "$f" "$post_hits"
     rm -f "$f"
     [ "$(wc -l < "$post_hits")" -eq 0 ]
 }
 
-@test "check_package_json: no postinstall hit when no postinstall key" {
+@test "check_postinstall_hooks: no hit when no postinstall key" {
     local f
     f="$(mktemp)"
     write_package_json "$f" "pkg" "1.0.0"
-    check_package_json "$f" "$pkg_hits" "$post_hits"
+    check_postinstall_hooks "$f" "$post_hits"
     rm -f "$f"
     [ "$(wc -l < "$post_hits")" -eq 0 ]
-}
-
-# --- check_requirements_txt ---
-
-@test "check_requirements_txt: always produces no hits (placeholder)" {
-    local f
-    f="$(mktemp)"
-    printf 'requests==2.28.0\nnumpy==1.24.0\n' > "$f"
-    check_requirements_txt "$f" "$pkg_hits"
-    rm -f "$f"
-    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
 # --- check_manifests ---
@@ -126,7 +115,7 @@ write_package_json() {
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
 }
 
-@test "check_manifests: routes requirements.txt to check_requirements_txt" {
+@test "check_manifests: produces no hits for requirements.txt" {
     local f
     f="$(mktemp)"
     printf 'requests==2.28.0\n' > "$f"
@@ -136,7 +125,7 @@ write_package_json() {
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
-@test "check_manifests: routes yml file to check_github_actions" {
+@test "check_manifests: produces no hits for yml files" {
     local f
     f="$(mktemp)"
     printf 'some: yaml\n' > "$f"
@@ -145,7 +134,7 @@ write_package_json() {
     [ "$(wc -l < "$post_hits")" -eq 0 ]
 }
 
-@test "check_manifests: routes yaml file to check_github_actions" {
+@test "check_manifests: produces no hits for yaml files" {
     local f
     f="$(mktemp)"
     printf 'some: yaml\n' > "$f"


### PR DESCRIPTION
- Break `main()` into focused functions + extract `_load_yaml_array`                                                  
- Remove placeholder stubs `check_requirements_txt` and `check_github_actions`
- Extract `check_postinstall_hooks` from `check_package_json`                                                         
- Hoist `emit_json_category` to top-level `_emit_json_category`
- Consolidate colour globals across `scan.sh` and `output.sh`