### PR TITLE
fix(cli): Escape package names in sed commands (#36)

### DIFF
--- a/src/package_check.sh
+++ b/src/package_check.sh
@@ -295,8 +295,10 @@ check_pyproject_toml() {
             sed -n 's/.*"[[:space:]]*\([0-9][^"]*\)"[[:space:]]*/\1/p' | head -1)" || true
         # PEP 517 list: "pkg==X.Y.Z"
         if [ -z "$installed_version" ]; then
+            local escaped_pkg
+            escaped_pkg="$(printf '%s' "$affected_pkg" | sed 's|/|\\/|g')"
             installed_version="$(grep "${affected_pkg}==" "$filepath" 2>/dev/null | \
-                sed -n "s/.*\"${affected_pkg}==\([^\"]*\)\".*/\1/p" | head -1)" || true
+                sed -n "s/.*\"${escaped_pkg}==\([^\"]*\)\".*/\1/p" | head -1)" || true
         fi
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086

--- a/tests/package_check.bats
+++ b/tests/package_check.bats
@@ -31,6 +31,16 @@ write_package_json() {
     grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
 }
 
+@test "check_package_json: handles scoped packages" {
+    local f
+    f="$(mktemp)"
+    write_package_json "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_package_json "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_package_json: no hit when version does not match" {
     local f
     f="$(mktemp)"
@@ -271,6 +281,16 @@ write_cargo_toml() {
     grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
 }
 
+@test "check_package_lock_json: handles scoped packages" {
+    local f
+    f="$(mktemp)"
+    write_package_lock_json "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_package_lock_json "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_package_lock_json: no hit when version does not match" {
     local f
     f="$(mktemp)"
@@ -336,6 +356,15 @@ write_cargo_toml() {
     grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
 }
 
+@test "check_yarn_lock: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_yarn_lock "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_yarn_lock "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_yarn_lock: no hit when version does not match" {
     local f; f="$(mktemp)"
     write_yarn_lock "$f" "eslint-config-prettier" "8.9.0"
@@ -361,6 +390,15 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
+}
+
+@test "check_pnpm_lock_yaml: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_pnpm_lock_yaml "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_pnpm_lock_yaml "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
 }
 
 @test "check_pnpm_lock_yaml: no hit when version does not match" {
@@ -398,6 +436,15 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "requests@2.28.0" "$pkg_hits"
+}
+
+@test "check_poetry_lock: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_toml_package_lock "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_poetry_lock "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
 }
 
 @test "check_poetry_lock: no hit when version does not match" {
@@ -445,6 +492,15 @@ write_cargo_toml() {
     grep -q "requests@2.28.0" "$pkg_hits"
 }
 
+@test "check_pipfile_lock: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_pipfile_lock "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_pipfile_lock "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_pipfile_lock: no hit when version does not match" {
     local f; f="$(mktemp)"
     write_pipfile_lock "$f" "requests" "2.27.0"
@@ -472,6 +528,15 @@ write_cargo_toml() {
     grep -q "rails@7.0.0" "$pkg_hits"
 }
 
+@test "check_gemfile_lock: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_gemfile_lock "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_gemfile_lock "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_gemfile_lock: no hit when version does not match" {
     local f; f="$(mktemp)"
     write_gemfile_lock "$f" "rails" "6.9.0"
@@ -497,6 +562,15 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "vendor/package@1.0.0" "$pkg_hits"
+}
+
+@test "check_composer_lock: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_composer_lock "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_composer_lock "$f" "$pkg_hits" "$post_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
 }
 
 @test "check_composer_lock: no hit when version does not match" {
@@ -553,6 +627,15 @@ write_cargo_toml() {
     grep -q "requests@2.28.0" "$pkg_hits"
 }
 
+@test "check_pipfile: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_pipfile "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_pipfile "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_pipfile: no hit when version does not match" {
     local f; f="$(mktemp)"
     write_pipfile "$f" "requests" "2.27.0"
@@ -604,6 +687,15 @@ write_cargo_toml() {
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
 }
 
+@test "check_pyproject_toml: handles scoped packages in PEP 517" {
+    local f; f="$(mktemp)"
+    write_pyproject_toml_pep517 "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_pyproject_toml "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_manifests: routes pyproject.toml to check_pyproject_toml and detects hit" {
     local f; f="$(mktemp)"
     write_pyproject_toml_poetry "$f" "requests" "2.28.0"
@@ -621,6 +713,15 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "rails@7.0.0" "$pkg_hits"
+}
+
+@test "check_gemfile: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_gemfile "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_gemfile "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
 }
 
 @test "check_gemfile: no hit when version does not match" {
@@ -658,6 +759,15 @@ write_cargo_toml() {
     grep -q "vendor/package@1.0.0" "$pkg_hits"
 }
 
+@test "check_composer_json: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_composer_json "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_composer_json "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
 @test "check_composer_json: no hit when version does not match" {
     local f; f="$(mktemp)"
     write_composer_json "$f" "vendor/package" "0.9.0"
@@ -691,6 +801,15 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "serde@1.0.130" "$pkg_hits"
+}
+
+@test "check_cargo_toml: handles scoped packages" {
+    local f; f="$(mktemp)"
+    write_cargo_toml "$f" "@uipath/orchestrator-tool" "1.0.1"
+    check_cargo_toml "$f" "$pkg_hits" "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
 }
 
 @test "check_cargo_toml: no hit when version does not match" {


### PR DESCRIPTION
Escape forward slashes in package names before using them as patterns in sed commands. This prevents syntax errors when processing scoped npm packages (e.g., @uipath/cli) in pyproject.toml and other manifest files where the package name is interpolated into a sed substitution command.

Changes:
- src/package_check.sh: Escaped slashes in affected_pkg within check_pyproject_toml.
- tests/package_check.bats: Added comprehensive regression tests for scoped packages across all supported package managers (npm, Yarn, pnpm, Poetry, uv, Pipenv, RubyGems, Composer, and Cargo).

Fixed #36