### PR TITLE
ci: Update github action versions to avoid Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check conventional commit format
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Run ShellCheck
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Bats
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Install bats
         uses: bats-core/bats-action@3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
 
       - name: Install bats
         uses: bats-core/bats-action@4.0.0
-
+        # https://github.com/bats-core/bats-action#about-caching
+        with:
+          support-path: "${{ github.workspace }}/tests/bats-support"
+          assert-path: "${{ github.workspace }}/tests/bats-assert"
+          detik-path: "${{ github.workspace }}/tests/bats-detik"
+          file-path: "${{ github.workspace }}/tests/bats-file"
       - name: Run tests
         run: bats tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Install bats
-        uses: bats-core/bats-action@3.0.0
+        uses: bats-core/bats-action@4.0.0
 
       - name: Run tests
         run: bats tests/


### PR DESCRIPTION
Problem:
Certain GitHub Actions were pinned to old versions which run on Node 20 (I've noticed that Claude likes to pick these old versions by default). This triggers deprecation warnings in the action logs e.g. https://github.com/madetech/cve-scanner/actions/runs/25791494680

Solution:
Update affected GitHub action packages to their latest versions.