### PR TITLE
fix(skill): Context support for other coding agents

### DIFF
--- a/.claude/skills/cve-scanner/SKILL.md
+++ b/.claude/skills/cve-scanner/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: cve-scanner
+description: Create a new CVE scanner.
+---
 # CVE IoC Scanner
 
 Populate `indicators.yaml` and generate a `README.md` to create a new CVE scanner.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Problem:
Agent support is limited to Claude-specific files and naming conventions.

Solution:
* Symlink AGENTS.md (used by every other coding agent) to CLAUDE.md, to avoid duplication and provide consistent context to other agents working in this repo (see https://www.buildthisnow.com/blog/guide/mechanics/agents-md-vs-claude-md)
* Add missing front matter to the cve-scanner skill (see https://agentskills.io/specification#frontmatter)