### PR TITLE
docs: Add determinism and portability contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,13 @@ Supported lock files and their corresponding check functions in `src/package_che
   - Use British English.
   - Always ensure that columns are aligned in tables.
 - Do not implement placeholder functions, they may lead to it looking like something is covered when it is not. If a function is relevant, implement it fully.
+
+## Determinism and portability contract
+
+- Portability and deterministic output are architectural constraints. Performance improvements are secondary to those constraints.
+- Detection trust takes precedence over throughput. The same repository should produce the same findings and the same output ordering across supported environments.
+- Optimisations must preserve a single default scan path. Do not add alternate "faster" or experimental modes that use different detection semantics.
+- Prefer sequential, behaviour-preserving optimisations first. Reduce redundant file reads and unnecessary process spawning before considering more invasive changes.
+- Treat Bash parallelism as high risk. Do not introduce parallel scanning in Bash unless the architecture changes first and deterministic equivalence is proven.
+- Treat the portability surface as Bash plus a documented safe subset of external tool behaviour. Avoid relying on non-portable or implementation-specific behaviour in `find`, `grep`, `awk`, `sed`, and `sort`, especially in hot paths.
+- Bash is a soft implementation constraint, not a hard one. Future changes may move scanner-core behaviour into another runtime if that reduces cross-environment verification risk without requiring users to preinstall an additional runtime.


### PR DESCRIPTION
Adds a determinism and portability contract to CLAUDE/AGENTS.md, as described in https://github.com/madetech/cve-scanner/issues/41