### PR TITLE
ci: Add multi-platform checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,16 +2,29 @@ name: Test
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:
-    name: Bats
-    runs-on: ubuntu-latest
+    name: Portability (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install bats
-        uses: bats-core/bats-action@3.0.0
+        uses: bats-core/bats-action@3.0.1
 
       - name: Run tests
+        shell: bash
         run: bats tests/
+
+      - name: Run scan smoke test
+        shell: bash
+        run: bash tests/smoke_scan.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ make setup
 make test
 ```
 
+The main GitHub Actions test workflow runs on `ubuntu-latest`, `macos-latest`, and
+`windows-latest` for both `push` and `pull_request` events. Each runner executes the
+full Bats suite and a small end-to-end smoke test for `scan.sh` to verify consistent
+behaviour across platforms.
+
+You can run the smoke test locally with:
+
+```shell
+bash tests/smoke_scan.sh
+```
+
 ### Commit messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and

--- a/tests/cli_smoke.bats
+++ b/tests/cli_smoke.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "scan.sh smoke suite passes" {
+    run bash "$BATS_TEST_DIRNAME/smoke_scan.sh"
+    [ "$status" -eq 0 ]
+}

--- a/tests/fixtures/smoke_scan/clean/app.js
+++ b/tests/fixtures/smoke_scan/clean/app.js
@@ -1,0 +1,1 @@
+console.log("clean fixture");

--- a/tests/fixtures/smoke_scan/infected/app.js
+++ b/tests/fixtures/smoke_scan/infected/app.js
@@ -1,0 +1,1 @@
+fetch("https://npnjs.com/pkg");

--- a/tests/smoke_scan.sh
+++ b/tests/smoke_scan.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+SCANNER_DIR="$REPO_ROOT/scanners/CVE-2025-54313"
+CLEAN_FIXTURE="$TEST_DIR/fixtures/smoke_scan/clean"
+INFECTED_FIXTURE="$TEST_DIR/fixtures/smoke_scan/infected"
+
+fail() {
+    printf 'smoke test failed: %s\n' "$1" >&2
+    exit 1
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2"
+    case "$haystack" in
+        *"$needle"*) ;;
+        *) fail "expected output to contain: $needle" ;;
+    esac
+}
+
+json_field() {
+    local field="$1"
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import json, sys; print(json.load(sys.stdin)[sys.argv[1]])' "$field"
+        return
+    fi
+
+    if command -v python >/dev/null 2>&1; then
+        python -c 'import json, sys; print(json.load(sys.stdin)[sys.argv[1]])' "$field"
+        return
+    fi
+
+    fail "python3 or python is required to parse JSON output"
+}
+
+assert_clean_scan() {
+    local output
+
+    output="$(bash "$REPO_ROOT/scan.sh" "$SCANNER_DIR" "$CLEAN_FIXTURE")" \
+        || fail "clean fixture should exit 0"
+
+    assert_contains "$output" "[CLEAN]"
+    assert_contains "$output" "No indicators of compromise found."
+}
+
+assert_infected_scan() {
+    local output status
+
+    set +e
+    output="$(bash "$REPO_ROOT/scan.sh" "$SCANNER_DIR" "$INFECTED_FIXTURE" 2>&1)"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "infected fixture should exit 1, got $status"
+    assert_contains "$output" "CVE-2025-54313"
+    assert_contains "$output" "[IOC STRINGS]"
+    assert_contains "$output" "npnjs.com"
+}
+
+assert_infected_json_scan() {
+    local output status total_hits cve
+
+    set +e
+    output="$(bash "$REPO_ROOT/scan.sh" "$SCANNER_DIR" --json "$INFECTED_FIXTURE" 2>&1)"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "infected JSON fixture should exit 1, got $status"
+
+    total_hits="$(printf '%s' "$output" | json_field total_hits)"
+    cve="$(printf '%s' "$output" | json_field cve)"
+
+    [ "$total_hits" = "1" ] || fail "expected total_hits=1, got $total_hits"
+    [ "$cve" = "CVE-2025-54313" ] || fail "expected cve=CVE-2025-54313, got $cve"
+    assert_contains "$output" "\"ioc_strings\""
+}
+
+run_smoke_scan() {
+    assert_clean_scan
+    assert_infected_scan
+    assert_infected_json_scan
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    run_smoke_scan
+fi


### PR DESCRIPTION
## Summary
- expand the test workflow into a Linux, macOS, and Windows matrix for push and pull_request
- run the full Bats suite under Bash on every runner and add a dedicated scan.sh smoke test step
- document the portability workflow and local smoke-test command in the README

## Testing
- bats tests/
- bash tests/smoke_scan.sh
- bash -n tests/smoke_scan.sh scan.sh

As suggested in this comment: https://github.com/madetech/cve-scanner/issues/41#issuecomment-4500186694