### PR TITLE
fix(cli): Harden package scan parsing and coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
           assert-path: "${{ github.workspace }}/tests/bats-assert"
           detik-path: "${{ github.workspace }}/tests/bats-detik"
           file-path: "${{ github.workspace }}/tests/bats-file"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         shell: bash
         run: bats tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
           assert-path: "${{ github.workspace }}/tests/bats-assert"
           detik-path: "${{ github.workspace }}/tests/bats-detik"
           file-path: "${{ github.workspace }}/tests/bats-file"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         shell: bash
         run: bats tests/
@@ -35,3 +37,4 @@ jobs:
       - name: Run scan smoke test
         shell: bash
         run: bash tests/smoke_scan.sh
+

--- a/src/awk/extract_named_object_field.awk
+++ b/src/awk/extract_named_object_field.awk
@@ -1,0 +1,84 @@
+# Find a named JSON object (`"object_key": { ... }`) and within that object's
+# body, extract the string value of `field_key`. If `value_prefix` is set,
+# the prefix is stripped from the matched value.
+#
+# Inputs:  -v object_key=<string> -v field_key=<string> -v value_prefix=<string>
+# Output:  prints the matched field value to stdout and exits.
+
+function starts_named_object(line, search_key,    start, rest) {
+    start = index(line, "\"" search_key "\"")
+    if (!start) {
+        return 0
+    }
+    rest = substr(line, start + length(search_key) + 2)
+    if (rest ~ /^[[:space:]]*:[[:space:]]*{/) {
+        return 1
+    }
+    if (rest ~ /^[[:space:]]*:[[:space:]]*$/) {
+        return 2
+    }
+    return 0
+}
+
+{
+    if (!in_object) {
+        if (awaiting_object_start) {
+            pending_line = $0
+            sub(/^[[:space:]]*/, "", pending_line)
+            if (substr(pending_line, 1, 1) == "{") {
+                in_object = 1
+                depth = 0
+                awaiting_object_start = 0
+            } else {
+                awaiting_object_start = 0
+            }
+        }
+
+        if (!in_object) {
+            object_state = starts_named_object($0, object_key)
+            if (object_state == 0) {
+                next
+            }
+            if (object_state == 2) {
+                awaiting_object_start = 1
+                next
+            }
+            in_object = 1
+            depth = 0
+        }
+    }
+
+    if (awaiting_field_value) {
+        value_line = $0
+        sub(/^[[:space:]]*/, "", value_line)
+        value = extract_json_string(value_line, 1, value_prefix)
+        if (value != "" && value != incomplete) {
+            print value
+            exit
+        }
+        awaiting_field_value = 0
+    }
+
+    depth += brace_delta($0)
+    if (depth == 1) {
+        value = extract_string_value($0, field_key, value_prefix)
+        if (value != "") {
+            print value
+            exit
+        }
+
+        field_pos = index($0, "\"" field_key "\"")
+        if (field_pos) {
+            remainder = substr($0, field_pos + length(field_key) + 2)
+            if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
+                awaiting_field_value = 1
+            }
+        }
+    }
+
+    if (depth <= 0) {
+        in_object = 0
+        depth = 0
+        awaiting_field_value = 0
+    }
+}

--- a/src/awk/extract_object_field_by_match.awk
+++ b/src/awk/extract_object_field_by_match.awk
@@ -1,0 +1,29 @@
+# Search a JSON array of objects for an object whose `match_key` equals
+# `match_value`, then print the value of `field_key` from that same object.
+# Used for composer.lock where each package is an unnamed object in
+# `"packages": [...]` and identified by its `"name"` field.
+#
+# Inputs:  -v match_key=<string> -v match_value=<string>
+#          -v field_key=<string> -v value_prefix=<string>
+# Output:  prints the matched field value to stdout and exits.
+
+{
+    depth += brace_delta($0)
+
+    if (target_depth > 0 && depth < target_depth) {
+        target_depth = 0
+    }
+
+    candidate = extract_string_value($0, match_key, "")
+    if (candidate == match_value) {
+        target_depth = depth
+    }
+
+    if (target_depth > 0 && depth == target_depth) {
+        value = extract_string_value($0, field_key, value_prefix)
+        if (value != "") {
+            print value
+            exit
+        }
+    }
+}

--- a/src/awk/extract_string_value.awk
+++ b/src/awk/extract_string_value.awk
@@ -1,0 +1,33 @@
+# Extract the string value paired with `key` anywhere in the JSON document.
+# Handles `"key": "value"` on one line and `"key":` followed by `"value"` on
+# the next line.
+#
+# Inputs:  -v key=<string>
+# Output:  prints the first matching value to stdout and exits.
+
+{
+    if (awaiting_value) {
+        value_line = $0
+        sub(/^[[:space:]]*/, "", value_line)
+        value = extract_json_string(value_line, 1, "")
+        if (value != "" && value != incomplete) {
+            print value
+            exit
+        }
+        awaiting_value = 0
+    }
+
+    value = extract_string_value($0, key, "")
+    if (value != "") {
+        print value
+        exit
+    }
+
+    key_pos = index($0, "\"" key "\"")
+    if (key_pos) {
+        remainder = substr($0, key_pos + length(key) + 2)
+        if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
+            awaiting_value = 1
+        }
+    }
+}

--- a/src/awk/json_helpers.awk
+++ b/src/awk/json_helpers.awk
@@ -7,7 +7,7 @@ BEGIN {
     incomplete = "\034"
 }
 
-function brace_delta(line,    tmp, opens, closes) {
+function brace_delta(line, tmp, opens, closes) {
     tmp = line
     opens = gsub(/\{/, "", tmp)
     tmp = line
@@ -18,7 +18,7 @@ function brace_delta(line,    tmp, opens, closes) {
 # Read a JSON string literal that begins at `start` in `text`. If `prefix` is
 # non-empty and the value begins with it, the prefix is stripped from the
 # returned value (used to peel e.g. "==" off pinned Pipenv versions).
-function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
+function extract_json_string(text, start, prefix, i, ch, escaped, value) {
     if (substr(text, start, 1) != "\"") {
         return ""
     }
@@ -47,7 +47,7 @@ function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
     return incomplete
 }
 
-function extract_string_value(line, search_key, prefix,    start, rest, value) {
+function extract_string_value(line, search_key, prefix, start, rest, value) {
     start = index(line, "\"" search_key "\"")
     if (!start) {
         return ""

--- a/src/awk/json_helpers.awk
+++ b/src/awk/json_helpers.awk
@@ -1,0 +1,65 @@
+# Shared helpers for the JSON extractor awk scripts.
+#
+# `incomplete` is a sentinel returned by extract_json_string when a string
+# literal is not terminated on the current line (multi-line JSON value).
+
+BEGIN {
+    incomplete = "\034"
+}
+
+function brace_delta(line,    tmp, opens, closes) {
+    tmp = line
+    opens = gsub(/\{/, "", tmp)
+    tmp = line
+    closes = gsub(/\}/, "", tmp)
+    return opens - closes
+}
+
+# Read a JSON string literal that begins at `start` in `text`. If `prefix` is
+# non-empty and the value begins with it, the prefix is stripped from the
+# returned value (used to peel e.g. "==" off pinned Pipenv versions).
+function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
+    if (substr(text, start, 1) != "\"") {
+        return ""
+    }
+    value = ""
+    escaped = 0
+    for (i = start + 1; i <= length(text); i++) {
+        ch = substr(text, i, 1)
+        if (escaped) {
+            value = value ch
+            escaped = 0
+            continue
+        }
+        if (ch == "\\") {
+            value = value ch
+            escaped = 1
+            continue
+        }
+        if (ch == "\"") {
+            if (prefix != "" && index(value, prefix) == 1) {
+                value = substr(value, length(prefix) + 1)
+            }
+            return value
+        }
+        value = value ch
+    }
+    return incomplete
+}
+
+function extract_string_value(line, search_key, prefix,    start, rest, value) {
+    start = index(line, "\"" search_key "\"")
+    if (!start) {
+        return ""
+    }
+    rest = substr(line, start + length(search_key) + 2)
+    sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+    if (substr(rest, 1, 1) != "\"") {
+        return ""
+    }
+    value = extract_json_string(rest, 1, prefix)
+    if (value == incomplete) {
+        return ""
+    }
+    return value
+}

--- a/src/package_check.sh
+++ b/src/package_check.sh
@@ -30,6 +30,339 @@ _record_package_hits() {
     done
 }
 
+_escape_ere() {
+    awk -v text="$1" 'BEGIN {
+        for (i = 1; i <= length(text); i++) {
+            ch = substr(text, i, 1)
+            if (ch == "\\" || ch == "[" || ch == "]" || ch == "(" || ch == ")" ||
+                ch == "{" || ch == "}" || ch == "." || ch == "^" || ch == "$" ||
+                ch == "*" || ch == "+" || ch == "?" || ch == "|") {
+                printf "\\%s", ch
+            } else {
+                printf "%s", ch
+            }
+        }
+    }'
+}
+
+_escape_bre() {
+    awk -v text="$1" 'BEGIN {
+        for (i = 1; i <= length(text); i++) {
+            ch = substr(text, i, 1)
+            if (ch == "\\" || ch == "/" || ch == "[" || ch == "]" ||
+                ch == "." || ch == "^" || ch == "$" || ch == "*") {
+                printf "\\%s", ch
+            } else {
+                printf "%s", ch
+            }
+        }
+    }'
+}
+
+_json_extract_string_value() {
+    local filepath="$1" json_key="$2"
+    awk -v key="$json_key" '
+        BEGIN {
+            incomplete = "\034"
+        }
+
+        function extract_json_string(text, start,    i, ch, escaped, value) {
+            if (substr(text, start, 1) != "\"") {
+                return ""
+            }
+            value = ""
+            escaped = 0
+            for (i = start + 1; i <= length(text); i++) {
+                ch = substr(text, i, 1)
+                if (escaped) {
+                    value = value ch
+                    escaped = 0
+                    continue
+                }
+                if (ch == "\\") {
+                    value = value ch
+                    escaped = 1
+                    continue
+                }
+                if (ch == "\"") {
+                    return value
+                }
+                value = value ch
+            }
+            return incomplete
+        }
+
+        function extract_string_value(line, search_key,    start, rest, value) {
+            start = index(line, "\"" search_key "\"")
+            if (!start) {
+                return ""
+            }
+            rest = substr(line, start + length(search_key) + 2)
+            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+            if (substr(rest, 1, 1) != "\"") {
+                return ""
+            }
+            value = extract_json_string(rest, 1)
+            if (value == incomplete) {
+                return ""
+            }
+            return value
+        }
+
+        {
+            if (awaiting_value) {
+                value_line = $0
+                sub(/^[[:space:]]*/, "", value_line)
+                value = extract_json_string(value_line, 1)
+                if (value != "" && value != incomplete) {
+                    print value
+                    exit
+                }
+                awaiting_value = 0
+            }
+
+            value = extract_string_value($0, key)
+            if (value != "") {
+                print value
+                exit
+            }
+
+            key_pos = index($0, "\"" key "\"")
+            if (key_pos) {
+                remainder = substr($0, key_pos + length(key) + 2)
+                if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
+                    awaiting_value = 1
+                }
+            }
+        }
+    ' "$filepath"
+}
+
+_json_extract_named_object_field() {
+    local filepath="$1" object_key="$2" field_key="$3" value_prefix="$4"
+    awk -v object_key="$object_key" -v field_key="$field_key" -v value_prefix="$value_prefix" '
+        BEGIN {
+            incomplete = "\034"
+        }
+
+        function brace_delta(line,    tmp, opens, closes) {
+            tmp = line
+            opens = gsub(/\{/, "", tmp)
+            tmp = line
+            closes = gsub(/\}/, "", tmp)
+            return opens - closes
+        }
+
+        function starts_named_object(line, search_key,    start, rest) {
+            start = index(line, "\"" search_key "\"")
+            if (!start) {
+                return 0
+            }
+            rest = substr(line, start + length(search_key) + 2)
+            if (rest ~ /^[[:space:]]*:[[:space:]]*{/) {
+                return 1
+            }
+            if (rest ~ /^[[:space:]]*:[[:space:]]*$/) {
+                return 2
+            }
+            return 0
+        }
+
+        function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
+            if (substr(text, start, 1) != "\"") {
+                return ""
+            }
+            value = ""
+            escaped = 0
+            for (i = start + 1; i <= length(text); i++) {
+                ch = substr(text, i, 1)
+                if (escaped) {
+                    value = value ch
+                    escaped = 0
+                    continue
+                }
+                if (ch == "\\") {
+                    value = value ch
+                    escaped = 1
+                    continue
+                }
+                if (ch == "\"") {
+                    if (prefix != "" && index(value, prefix) == 1) {
+                        value = substr(value, length(prefix) + 1)
+                    }
+                    return value
+                }
+                value = value ch
+            }
+            return incomplete
+        }
+
+        function extract_string_value(line, search_key, prefix,    start, rest, value) {
+            start = index(line, "\"" search_key "\"")
+            if (!start) {
+                return ""
+            }
+            rest = substr(line, start + length(search_key) + 2)
+            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+            if (substr(rest, 1, 1) != "\"") {
+                return ""
+            }
+            value = extract_json_string(rest, 1, prefix)
+            if (value == incomplete) {
+                return ""
+            }
+            return value
+        }
+
+        {
+            if (!in_object) {
+                if (awaiting_object_start) {
+                    pending_line = $0
+                    sub(/^[[:space:]]*/, "", pending_line)
+                    if (substr(pending_line, 1, 1) == "{") {
+                        in_object = 1
+                        depth = 0
+                        awaiting_object_start = 0
+                    } else {
+                        awaiting_object_start = 0
+                    }
+                }
+
+                if (!in_object) {
+                    object_state = starts_named_object($0, object_key)
+                    if (object_state == 0) {
+                        next
+                    }
+                    if (object_state == 2) {
+                        awaiting_object_start = 1
+                        next
+                    }
+                    in_object = 1
+                    depth = 0
+                }
+            }
+
+            if (awaiting_field_value) {
+                value_line = $0
+                sub(/^[[:space:]]*/, "", value_line)
+                value = extract_json_string(value_line, 1, value_prefix)
+                if (value != "" && value != incomplete) {
+                    print value
+                    exit
+                }
+                awaiting_field_value = 0
+            }
+
+            depth += brace_delta($0)
+            if (depth == 1) {
+                value = extract_string_value($0, field_key, value_prefix)
+                if (value != "") {
+                    print value
+                    exit
+                }
+
+                field_pos = index($0, "\"" field_key "\"")
+                if (field_pos) {
+                    remainder = substr($0, field_pos + length(field_key) + 2)
+                    if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
+                        awaiting_field_value = 1
+                    }
+                }
+            }
+
+            if (depth <= 0) {
+                in_object = 0
+                depth = 0
+                awaiting_field_value = 0
+            }
+        }
+    ' "$filepath"
+}
+
+_json_extract_object_field_by_match() {
+    local filepath="$1" match_key="$2" match_value="$3" field_key="$4" value_prefix="$5"
+    awk -v match_key="$match_key" -v match_value="$match_value" -v field_key="$field_key" -v value_prefix="$value_prefix" '
+        BEGIN {
+            incomplete = "\034"
+        }
+
+        function brace_delta(line,    tmp, opens, closes) {
+            tmp = line
+            opens = gsub(/\{/, "", tmp)
+            tmp = line
+            closes = gsub(/\}/, "", tmp)
+            return opens - closes
+        }
+
+        function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
+            if (substr(text, start, 1) != "\"") {
+                return ""
+            }
+            value = ""
+            escaped = 0
+            for (i = start + 1; i <= length(text); i++) {
+                ch = substr(text, i, 1)
+                if (escaped) {
+                    value = value ch
+                    escaped = 0
+                    continue
+                }
+                if (ch == "\\") {
+                    value = value ch
+                    escaped = 1
+                    continue
+                }
+                if (ch == "\"") {
+                    if (prefix != "" && index(value, prefix) == 1) {
+                        value = substr(value, length(prefix) + 1)
+                    }
+                    return value
+                }
+                value = value ch
+            }
+            return incomplete
+        }
+
+        function extract_string_value(line, search_key, prefix,    start, rest, value) {
+            start = index(line, "\"" search_key "\"")
+            if (!start) {
+                return ""
+            }
+            rest = substr(line, start + length(search_key) + 2)
+            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+            if (substr(rest, 1, 1) != "\"") {
+                return ""
+            }
+            value = extract_json_string(rest, 1, prefix)
+            if (value == incomplete) {
+                return ""
+            }
+            return value
+        }
+
+        {
+            depth += brace_delta($0)
+
+            if (target_depth > 0 && depth < target_depth) {
+                target_depth = 0
+            }
+
+            candidate = extract_string_value($0, match_key, "")
+            if (candidate == match_value) {
+                target_depth = depth
+            }
+
+            if (target_depth > 0 && depth == target_depth) {
+                value = extract_string_value($0, field_key, value_prefix)
+                if (value != "") {
+                    print value
+                    exit
+                }
+            }
+        }
+    ' "$filepath"
+}
+
 # Usage: check_package_json <filepath> <package_hits_file> <affected_package_entry>...
 #
 # Each affected_package_entry has the form "package-name|version1 version2 ..."
@@ -62,7 +395,7 @@ check_postinstall_hooks() {
     grep -q '"postinstall"' "$filepath" 2>/dev/null || return 0
 
     local postinstall_value
-    postinstall_value="$(grep -A1 '"postinstall"' "$filepath" | tail -1)" || true
+    postinstall_value="$(_json_extract_string_value "$filepath" "postinstall")" || true
     local suspicious_string
     for suspicious_string in "node-gyp.dll" "crashreporter.dll" "rundll32" "install.js" "logDiskSpace" "child_process"; do
         if printf '%s' "$postinstall_value" | grep -qF "$suspicious_string" 2>/dev/null; then
@@ -86,7 +419,7 @@ check_package_lock_json() {
         malicious_versions="${package_entry##*|}"
 
         local installed_version
-        installed_version="$(grep -A5 "\"node_modules/${affected_pkg}\"" "$filepath" | grep -m1 '"version"' | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')" || true
+        installed_version="$(_json_extract_named_object_field "$filepath" "node_modules/${affected_pkg}" "version" "")" || true
 
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086  # word splitting intentional
@@ -161,8 +494,8 @@ _check_toml_package_lock() {
         local affected_pkg malicious_versions
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
-        local installed_version
-        installed_version="$(awk -v pkg="$affected_pkg" '
+        local installed_versions installed_version
+        installed_versions="$(awk -v pkg="$affected_pkg" '
             /^\[\[package\]\]/ { name = ""; version = "" }
             /^name = / {
                 n = substr($0, 9); gsub(/^"|"$/, "", n); name = n
@@ -171,10 +504,17 @@ _check_toml_package_lock() {
                 v = substr($0, 11); gsub(/^"|"$/, "", v); print v
             }
         ' "$filepath")" || true
-        if [ -n "$installed_version" ]; then
+        while IFS= read -r installed_version; do
+            [ -n "$installed_version" ] || continue
             # shellcheck disable=SC2086  # word splitting intentional
             _record_package_hits "$filepath" "$affected_pkg" "$installed_version" "$package_hits_file" $malicious_versions
-        fi
+            if [ -s "$package_hits_file" ]; then
+                break
+            fi
+        done <<EOF
+$installed_versions
+EOF
+        :
     done
 }
 
@@ -209,9 +549,7 @@ check_pipfile_lock() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version
-        installed_version="$(grep -A5 "\"${affected_pkg}\":" "$filepath" 2>/dev/null | \
-            grep -m1 '"version"' | \
-            sed 's/.*"version"[[:space:]]*:[[:space:]]*"==\([^"]*\)".*/\1/')" || true
+        installed_version="$(_json_extract_named_object_field "$filepath" "$affected_pkg" "version" "==")" || true
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086  # word splitting intentional
             _record_package_hits "$filepath" "$affected_pkg" "$installed_version" "$package_hits_file" $malicious_versions
@@ -253,9 +591,7 @@ check_composer_lock() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version
-        installed_version="$(grep -A5 "\"name\": \"${affected_pkg}\"" "$filepath" 2>/dev/null | \
-            grep -m1 '"version"' | \
-            sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')" || true
+        installed_version="$(_json_extract_object_field_by_match "$filepath" "name" "$affected_pkg" "version" "")" || true
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086  # word splitting intentional
             _record_package_hits "$filepath" "$affected_pkg" "$installed_version" "$package_hits_file" $malicious_versions
@@ -271,8 +607,9 @@ check_pipfile() {
         local affected_pkg malicious_versions
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
-        local installed_version
-        installed_version="$(grep -E "^${affected_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
+        local installed_version escaped_pkg
+        escaped_pkg="$(_escape_ere "$affected_pkg")"
+        installed_version="$(grep -E "^${escaped_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
             sed -n 's/.*"==\([^"]*\)".*/\1/p')" || true
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086
@@ -289,16 +626,17 @@ check_pyproject_toml() {
         local affected_pkg malicious_versions
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
-        local installed_version
+        local installed_version escaped_pkg
+        escaped_pkg="$(_escape_ere "$affected_pkg")"
         # Poetry/uv table: pkg = "X.Y.Z" — value starts with a digit (no operator)
-        installed_version="$(grep -E "^[[:space:]]*${affected_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
+        installed_version="$(grep -E "^[[:space:]]*${escaped_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
             sed -n 's/.*"[[:space:]]*\([0-9][^"]*\)"[[:space:]]*/\1/p' | head -1)" || true
         # PEP 517 list: "pkg==X.Y.Z"
         if [ -z "$installed_version" ]; then
-            local escaped_pkg
-            escaped_pkg="$(printf '%s' "$affected_pkg" | sed 's|/|\\/|g')"
-            installed_version="$(grep "${affected_pkg}==" "$filepath" 2>/dev/null | \
-                sed -n "s/.*\"${escaped_pkg}==\([^\"]*\)\".*/\1/p" | head -1)" || true
+            local escaped_sed_pkg
+            escaped_sed_pkg="$(_escape_bre "$affected_pkg")"
+            installed_version="$(grep -F "${affected_pkg}==" "$filepath" 2>/dev/null | \
+                sed -n "s/.*\"${escaped_sed_pkg}==\([^\"]*\)\".*/\1/p" | head -1)" || true
         fi
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086
@@ -315,9 +653,10 @@ check_gemfile() {
         local affected_pkg malicious_versions
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
-        local installed_version
+        local installed_version escaped_pkg
+        escaped_pkg="$(_escape_ere "$affected_pkg")"
         # gem 'pkg', 'X.Y.Z' or gem 'pkg', '= X.Y.Z' (single or double quotes)
-        installed_version="$(grep -E "gem ['\"]${affected_pkg}['\"]" "$filepath" 2>/dev/null | \
+        installed_version="$(grep -E "gem ['\"]${escaped_pkg}['\"]" "$filepath" 2>/dev/null | \
             sed -n "s/.*['\"][[:space:]]*=[[:space:]]*\([0-9][^'\"]*\)['\"].*/\1/p
                     s/.*,[[:space:]]*['\"][[:space:]]*\([0-9][^'\"]*\)['\"].*/\1/p" | head -1)" || true
         if [ -n "$installed_version" ]; then
@@ -336,8 +675,8 @@ check_composer_json() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version escaped_pkg
-        escaped_pkg="$(printf '%s' "$affected_pkg" | sed 's|/|\\/|g')"
-        installed_version="$(grep "\"${affected_pkg}\"" "$filepath" 2>/dev/null | \
+        escaped_pkg="$(_escape_bre "$affected_pkg")"
+        installed_version="$(grep -F "\"${affected_pkg}\"" "$filepath" 2>/dev/null | \
             sed -n "s/.*\"${escaped_pkg}\"[[:space:]]*:[[:space:]]*\"\([0-9][^\"]*\)\".*/\1/p" | head -1)" || true
         if [ -n "$installed_version" ]; then
             # shellcheck disable=SC2086

--- a/src/package_check.sh
+++ b/src/package_check.sh
@@ -3,6 +3,8 @@
 # shellcheck source=src/version.sh
 source "$(dirname "${BASH_SOURCE[0]}")/version.sh"
 
+_AWK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/awk" && pwd)"
+
 # Usage: _record_package_hits <filepath> <pkg_name> <installed_version> <package_hits_file> <malicious_version>...
 # Word-splits malicious_versions intentionally — caller must pass $malicious_versions unquoted.
 _record_package_hits() {
@@ -30,7 +32,11 @@ _record_package_hits() {
     done
 }
 
-_escape_ere() {
+# Escape regex metacharacters in a literal string so it can be interpolated
+# into an Extended Regular Expression (ERE) — i.e. the pattern given to
+# `grep -E`. ERE treats `( ) { } + ? |` as metacharacters in addition to the
+# BRE set, so they must be escaped here.
+_escape_for_grep_e() {
     awk -v text="$1" 'BEGIN {
         for (i = 1; i <= length(text); i++) {
             ch = substr(text, i, 1)
@@ -45,7 +51,13 @@ _escape_ere() {
     }'
 }
 
-_escape_bre() {
+# Escape regex metacharacters in a literal string so it can be interpolated
+# into a Basic Regular Expression (BRE) used inside a `sed s/.../.../` pattern.
+# Also escapes `/` because that is sed's default s-command delimiter; without
+# it, a `/` in the input would prematurely terminate the pattern.
+# Only safe for BRE `sed` (without `-E`/`-r`); ERE-mode sed would need
+# `( ) { } + ? |` escaped too.
+_escape_for_sed() {
     awk -v text="$1" 'BEGIN {
         for (i = 1; i <= length(text); i++) {
             ch = substr(text, i, 1)
@@ -61,306 +73,23 @@ _escape_bre() {
 
 _json_extract_string_value() {
     local filepath="$1" json_key="$2"
-    awk -v key="$json_key" '
-        BEGIN {
-            incomplete = "\034"
-        }
-
-        function extract_json_string(text, start,    i, ch, escaped, value) {
-            if (substr(text, start, 1) != "\"") {
-                return ""
-            }
-            value = ""
-            escaped = 0
-            for (i = start + 1; i <= length(text); i++) {
-                ch = substr(text, i, 1)
-                if (escaped) {
-                    value = value ch
-                    escaped = 0
-                    continue
-                }
-                if (ch == "\\") {
-                    value = value ch
-                    escaped = 1
-                    continue
-                }
-                if (ch == "\"") {
-                    return value
-                }
-                value = value ch
-            }
-            return incomplete
-        }
-
-        function extract_string_value(line, search_key,    start, rest, value) {
-            start = index(line, "\"" search_key "\"")
-            if (!start) {
-                return ""
-            }
-            rest = substr(line, start + length(search_key) + 2)
-            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
-            if (substr(rest, 1, 1) != "\"") {
-                return ""
-            }
-            value = extract_json_string(rest, 1)
-            if (value == incomplete) {
-                return ""
-            }
-            return value
-        }
-
-        {
-            if (awaiting_value) {
-                value_line = $0
-                sub(/^[[:space:]]*/, "", value_line)
-                value = extract_json_string(value_line, 1)
-                if (value != "" && value != incomplete) {
-                    print value
-                    exit
-                }
-                awaiting_value = 0
-            }
-
-            value = extract_string_value($0, key)
-            if (value != "") {
-                print value
-                exit
-            }
-
-            key_pos = index($0, "\"" key "\"")
-            if (key_pos) {
-                remainder = substr($0, key_pos + length(key) + 2)
-                if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
-                    awaiting_value = 1
-                }
-            }
-        }
-    ' "$filepath"
+    awk -f "$_AWK_DIR/json_helpers.awk" -f "$_AWK_DIR/extract_string_value.awk" \
+        -v key="$json_key" "$filepath"
 }
 
 _json_extract_named_object_field() {
     local filepath="$1" object_key="$2" field_key="$3" value_prefix="$4"
-    awk -v object_key="$object_key" -v field_key="$field_key" -v value_prefix="$value_prefix" '
-        BEGIN {
-            incomplete = "\034"
-        }
-
-        function brace_delta(line,    tmp, opens, closes) {
-            tmp = line
-            opens = gsub(/\{/, "", tmp)
-            tmp = line
-            closes = gsub(/\}/, "", tmp)
-            return opens - closes
-        }
-
-        function starts_named_object(line, search_key,    start, rest) {
-            start = index(line, "\"" search_key "\"")
-            if (!start) {
-                return 0
-            }
-            rest = substr(line, start + length(search_key) + 2)
-            if (rest ~ /^[[:space:]]*:[[:space:]]*{/) {
-                return 1
-            }
-            if (rest ~ /^[[:space:]]*:[[:space:]]*$/) {
-                return 2
-            }
-            return 0
-        }
-
-        function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
-            if (substr(text, start, 1) != "\"") {
-                return ""
-            }
-            value = ""
-            escaped = 0
-            for (i = start + 1; i <= length(text); i++) {
-                ch = substr(text, i, 1)
-                if (escaped) {
-                    value = value ch
-                    escaped = 0
-                    continue
-                }
-                if (ch == "\\") {
-                    value = value ch
-                    escaped = 1
-                    continue
-                }
-                if (ch == "\"") {
-                    if (prefix != "" && index(value, prefix) == 1) {
-                        value = substr(value, length(prefix) + 1)
-                    }
-                    return value
-                }
-                value = value ch
-            }
-            return incomplete
-        }
-
-        function extract_string_value(line, search_key, prefix,    start, rest, value) {
-            start = index(line, "\"" search_key "\"")
-            if (!start) {
-                return ""
-            }
-            rest = substr(line, start + length(search_key) + 2)
-            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
-            if (substr(rest, 1, 1) != "\"") {
-                return ""
-            }
-            value = extract_json_string(rest, 1, prefix)
-            if (value == incomplete) {
-                return ""
-            }
-            return value
-        }
-
-        {
-            if (!in_object) {
-                if (awaiting_object_start) {
-                    pending_line = $0
-                    sub(/^[[:space:]]*/, "", pending_line)
-                    if (substr(pending_line, 1, 1) == "{") {
-                        in_object = 1
-                        depth = 0
-                        awaiting_object_start = 0
-                    } else {
-                        awaiting_object_start = 0
-                    }
-                }
-
-                if (!in_object) {
-                    object_state = starts_named_object($0, object_key)
-                    if (object_state == 0) {
-                        next
-                    }
-                    if (object_state == 2) {
-                        awaiting_object_start = 1
-                        next
-                    }
-                    in_object = 1
-                    depth = 0
-                }
-            }
-
-            if (awaiting_field_value) {
-                value_line = $0
-                sub(/^[[:space:]]*/, "", value_line)
-                value = extract_json_string(value_line, 1, value_prefix)
-                if (value != "" && value != incomplete) {
-                    print value
-                    exit
-                }
-                awaiting_field_value = 0
-            }
-
-            depth += brace_delta($0)
-            if (depth == 1) {
-                value = extract_string_value($0, field_key, value_prefix)
-                if (value != "") {
-                    print value
-                    exit
-                }
-
-                field_pos = index($0, "\"" field_key "\"")
-                if (field_pos) {
-                    remainder = substr($0, field_pos + length(field_key) + 2)
-                    if (remainder ~ /^[[:space:]]*:[[:space:]]*$/) {
-                        awaiting_field_value = 1
-                    }
-                }
-            }
-
-            if (depth <= 0) {
-                in_object = 0
-                depth = 0
-                awaiting_field_value = 0
-            }
-        }
-    ' "$filepath"
+    awk -f "$_AWK_DIR/json_helpers.awk" -f "$_AWK_DIR/extract_named_object_field.awk" \
+        -v object_key="$object_key" -v field_key="$field_key" -v value_prefix="$value_prefix" \
+        "$filepath"
 }
 
 _json_extract_object_field_by_match() {
     local filepath="$1" match_key="$2" match_value="$3" field_key="$4" value_prefix="$5"
-    awk -v match_key="$match_key" -v match_value="$match_value" -v field_key="$field_key" -v value_prefix="$value_prefix" '
-        BEGIN {
-            incomplete = "\034"
-        }
-
-        function brace_delta(line,    tmp, opens, closes) {
-            tmp = line
-            opens = gsub(/\{/, "", tmp)
-            tmp = line
-            closes = gsub(/\}/, "", tmp)
-            return opens - closes
-        }
-
-        function extract_json_string(text, start, prefix,    i, ch, escaped, value) {
-            if (substr(text, start, 1) != "\"") {
-                return ""
-            }
-            value = ""
-            escaped = 0
-            for (i = start + 1; i <= length(text); i++) {
-                ch = substr(text, i, 1)
-                if (escaped) {
-                    value = value ch
-                    escaped = 0
-                    continue
-                }
-                if (ch == "\\") {
-                    value = value ch
-                    escaped = 1
-                    continue
-                }
-                if (ch == "\"") {
-                    if (prefix != "" && index(value, prefix) == 1) {
-                        value = substr(value, length(prefix) + 1)
-                    }
-                    return value
-                }
-                value = value ch
-            }
-            return incomplete
-        }
-
-        function extract_string_value(line, search_key, prefix,    start, rest, value) {
-            start = index(line, "\"" search_key "\"")
-            if (!start) {
-                return ""
-            }
-            rest = substr(line, start + length(search_key) + 2)
-            sub(/^[[:space:]]*:[[:space:]]*/, "", rest)
-            if (substr(rest, 1, 1) != "\"") {
-                return ""
-            }
-            value = extract_json_string(rest, 1, prefix)
-            if (value == incomplete) {
-                return ""
-            }
-            return value
-        }
-
-        {
-            depth += brace_delta($0)
-
-            if (target_depth > 0 && depth < target_depth) {
-                target_depth = 0
-            }
-
-            candidate = extract_string_value($0, match_key, "")
-            if (candidate == match_value) {
-                target_depth = depth
-            }
-
-            if (target_depth > 0 && depth == target_depth) {
-                value = extract_string_value($0, field_key, value_prefix)
-                if (value != "") {
-                    print value
-                    exit
-                }
-            }
-        }
-    ' "$filepath"
+    awk -f "$_AWK_DIR/json_helpers.awk" -f "$_AWK_DIR/extract_object_field_by_match.awk" \
+        -v match_key="$match_key" -v match_value="$match_value" \
+        -v field_key="$field_key" -v value_prefix="$value_prefix" \
+        "$filepath"
 }
 
 # Usage: check_package_json <filepath> <package_hits_file> <affected_package_entry>...
@@ -608,7 +337,7 @@ check_pipfile() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version escaped_pkg
-        escaped_pkg="$(_escape_ere "$affected_pkg")"
+        escaped_pkg="$(_escape_for_grep_e "$affected_pkg")"
         installed_version="$(grep -E "^${escaped_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
             sed -n 's/.*"==\([^"]*\)".*/\1/p')" || true
         if [ -n "$installed_version" ]; then
@@ -627,14 +356,14 @@ check_pyproject_toml() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version escaped_pkg
-        escaped_pkg="$(_escape_ere "$affected_pkg")"
+        escaped_pkg="$(_escape_for_grep_e "$affected_pkg")"
         # Poetry/uv table: pkg = "X.Y.Z" — value starts with a digit (no operator)
         installed_version="$(grep -E "^[[:space:]]*${escaped_pkg}[[:space:]]*=" "$filepath" 2>/dev/null | \
             sed -n 's/.*"[[:space:]]*\([0-9][^"]*\)"[[:space:]]*/\1/p' | head -1)" || true
         # PEP 517 list: "pkg==X.Y.Z"
         if [ -z "$installed_version" ]; then
             local escaped_sed_pkg
-            escaped_sed_pkg="$(_escape_bre "$affected_pkg")"
+            escaped_sed_pkg="$(_escape_for_sed "$affected_pkg")"
             installed_version="$(grep -F "${affected_pkg}==" "$filepath" 2>/dev/null | \
                 sed -n "s/.*\"${escaped_sed_pkg}==\([^\"]*\)\".*/\1/p" | head -1)" || true
         fi
@@ -654,7 +383,7 @@ check_gemfile() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version escaped_pkg
-        escaped_pkg="$(_escape_ere "$affected_pkg")"
+        escaped_pkg="$(_escape_for_grep_e "$affected_pkg")"
         # gem 'pkg', 'X.Y.Z' or gem 'pkg', '= X.Y.Z' (single or double quotes)
         installed_version="$(grep -E "gem ['\"]${escaped_pkg}['\"]" "$filepath" 2>/dev/null | \
             sed -n "s/.*['\"][[:space:]]*=[[:space:]]*\([0-9][^'\"]*\)['\"].*/\1/p
@@ -675,7 +404,7 @@ check_composer_json() {
         affected_pkg="${package_entry%%|*}"
         malicious_versions="${package_entry##*|}"
         local installed_version escaped_pkg
-        escaped_pkg="$(_escape_bre "$affected_pkg")"
+        escaped_pkg="$(_escape_for_sed "$affected_pkg")"
         installed_version="$(grep -F "\"${affected_pkg}\"" "$filepath" 2>/dev/null | \
             sed -n "s/.*\"${escaped_pkg}\"[[:space:]]*:[[:space:]]*\"\([0-9][^\"]*\)\".*/\1/p" | head -1)" || true
         if [ -n "$installed_version" ]; then

--- a/tests/package_check.bats
+++ b/tests/package_check.bats
@@ -113,6 +113,26 @@ write_package_json() {
     [ "$(wc -l < "$post_hits")" -eq 0 ]
 }
 
+@test "check_postinstall_hooks: records hit when postinstall value is on a later line inside scripts" {
+    local f
+    f="$(mktemp)"
+    printf '{\n  "name": "pkg",\n  "scripts": {\n    "build": "node build.js",\n    "postinstall":\n      "node child_process",\n    "test": "node test.js"\n  }\n}\n' > "$f"
+    check_postinstall_hooks "$f" "$post_hits"
+    rm -f "$f"
+    [ "$(wc -l < "$post_hits")" -eq 1 ]
+    grep -q "child_process" "$post_hits"
+}
+
+@test "check_postinstall_hooks: records hit when postinstall contains escaped quotes before suspicious string" {
+    local f
+    f="$(mktemp)"
+    printf '{\n  "scripts": {\n    "postinstall": "node -e \\"require(\\\\\\"child_process\\\\\\")\\""\n  }\n}\n' > "$f"
+    check_postinstall_hooks "$f" "$post_hits"
+    rm -f "$f"
+    [ "$(wc -l < "$post_hits")" -eq 1 ]
+    grep -q "child_process" "$post_hits"
+}
+
 # --- check_manifests ---
 
 @test "check_manifests: routes package.json to check_package_json" {
@@ -322,6 +342,39 @@ write_cargo_toml() {
     grep -q "next@15.0.3" "$pkg_hits"
 }
 
+@test "check_package_lock_json: records hit when entry has intervening lines before version" {
+    local f
+    f="$(mktemp)"
+    printf '{\n  "lockfileVersion": 2,\n  "packages": {\n    "node_modules/eslint-config-prettier": {\n      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.1.tgz",\n      "integrity": "sha512-fake",\n      "version": "8.10.1"\n    }\n  }\n}\n' > "$f"
+    check_package_lock_json "$f" "$pkg_hits" "$post_hits" \
+        "eslint-config-prettier|8.10.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
+}
+
+@test "check_package_lock_json: records hit for multi-line entry with nested objects" {
+    local f
+    f="$(mktemp)"
+    printf '{\n  "lockfileVersion": 3,\n  "packages": {\n    "node_modules/@uipath/orchestrator-tool": {\n      "dependencies": {\n        "left-pad": "^1.3.0"\n      },\n      "engines": {\n        "node": ">=18"\n      },\n      "version": "1.0.1"\n    }\n  }\n}\n' > "$f"
+    check_package_lock_json "$f" "$pkg_hits" "$post_hits" \
+        "@uipath/orchestrator-tool|1.0.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
+@test "check_package_lock_json: records hit when entry object starts on next line" {
+    local f
+    f="$(mktemp)"
+    printf '{\n  "lockfileVersion": 2,\n  "packages": {\n    "node_modules/eslint-config-prettier":\n    {\n      "version": "8.10.1"\n    }\n  }\n}\n' > "$f"
+    check_package_lock_json "$f" "$pkg_hits" "$post_hits" \
+        "eslint-config-prettier|8.10.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "eslint-config-prettier@8.10.1" "$pkg_hits"
+}
+
 # --- check_manifests lock file routing ---
 
 @test "check_manifests: routes package-lock.json to check_package_lock_json" {
@@ -473,6 +526,15 @@ write_cargo_toml() {
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
 }
 
+@test "check_cargo_lock: records hit when duplicate package entries include a malicious version" {
+    local f; f="$(mktemp)"
+    printf '[[package]]\nname = "serde"\nversion = "1.0.129"\n\n[[package]]\nname = "serde"\nversion = "1.0.130"\n' > "$f"
+    check_cargo_lock "$f" "$pkg_hits" "$post_hits" "serde|1.0.130"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "serde@1.0.130" "$pkg_hits"
+}
+
 @test "check_manifests: routes uv.lock to check_uv_lock" {
     local f; f="$(mktemp)"
     write_toml_package_lock "$f" "requests" "2.28.0"
@@ -507,6 +569,24 @@ write_cargo_toml() {
     check_pipfile_lock "$f" "$pkg_hits" "$post_hits" "requests|2.28.0"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
+}
+
+@test "check_pipfile_lock: records hit when version is not within five lines of package key" {
+    local f; f="$(mktemp)"
+    printf '{\n    "default": {\n        "requests": {\n            "hashes": [\n                "sha256:first",\n                "sha256:second"\n            ],\n            "markers": "python_version >= '\''3.8'\''",\n            "version": "==2.28.0"\n        }\n    }\n}\n' > "$f"
+    check_pipfile_lock "$f" "$pkg_hits" "$post_hits" "requests|2.28.0"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "requests@2.28.0" "$pkg_hits"
+}
+
+@test "check_pipfile_lock: records hit when package object starts on next line" {
+    local f; f="$(mktemp)"
+    printf '{\n    "default": {\n        "requests":\n        {\n            "version": "==2.28.0"\n        }\n    }\n}\n' > "$f"
+    check_pipfile_lock "$f" "$pkg_hits" "$post_hits" "requests|2.28.0"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "requests@2.28.0" "$pkg_hits"
 }
 
 @test "check_manifests: routes Pipfile.lock to check_pipfile_lock" {
@@ -581,6 +661,15 @@ write_cargo_toml() {
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
+@test "check_composer_lock: records hit when version follows nested metadata" {
+    local f; f="$(mktemp)"
+    printf '{\n    "packages": [\n        {\n            "name": "vendor/package",\n            "autoload": {\n                "psr-4": {\n                    "Vendor\\\\Package\\\\": "src/"\n                }\n            },\n            "version": "1.0.0"\n        }\n    ]\n}\n' > "$f"
+    check_composer_lock "$f" "$pkg_hits" "$post_hits" "vendor/package|1.0.0"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "vendor/package@1.0.0" "$pkg_hits"
+}
+
 @test "check_manifests: routes composer.lock to check_composer_lock" {
     local f; f="$(mktemp)"
     write_composer_lock "$f" "vendor/package" "1.0.0"
@@ -652,6 +741,23 @@ write_cargo_toml() {
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
+@test "check_pipfile: matches exact package names containing regex metacharacters" {
+    local f; f="$(mktemp)"
+    write_pipfile "$f" "zope.interface" "6.1"
+    check_pipfile "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "zope.interface@6.1" "$pkg_hits"
+}
+
+@test "check_pipfile: does not treat regex metacharacters in package names as wildcards" {
+    local f; f="$(mktemp)"
+    write_pipfile "$f" "zopexinterface" "6.1"
+    check_pipfile "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
+}
+
 @test "check_manifests: routes Pipfile to check_pipfile and detects hit" {
     local f; f="$(mktemp)"
     write_pipfile "$f" "requests" "2.28.0"
@@ -694,6 +800,40 @@ write_cargo_toml() {
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 1 ]
     grep -q "@uipath/orchestrator-tool@1.0.1" "$pkg_hits"
+}
+
+@test "check_pyproject_toml: matches exact Poetry package names containing regex metacharacters" {
+    local f; f="$(mktemp)"
+    write_pyproject_toml_poetry "$f" "zope.interface" "6.1"
+    check_pyproject_toml "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "zope.interface@6.1" "$pkg_hits"
+}
+
+@test "check_pyproject_toml: does not treat regex metacharacters in Poetry names as wildcards" {
+    local f; f="$(mktemp)"
+    write_pyproject_toml_poetry "$f" "zopexinterface" "6.1"
+    check_pyproject_toml "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
+}
+
+@test "check_pyproject_toml: matches exact PEP 517 package names containing regex metacharacters" {
+    local f; f="$(mktemp)"
+    write_pyproject_toml_pep517 "$f" "zope.interface" "6.1"
+    check_pyproject_toml "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "zope.interface@6.1" "$pkg_hits"
+}
+
+@test "check_pyproject_toml: does not treat regex metacharacters in PEP 517 names as wildcards" {
+    local f; f="$(mktemp)"
+    write_pyproject_toml_pep517 "$f" "zopexinterface" "6.1"
+    check_pyproject_toml "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
 @test "check_manifests: routes pyproject.toml to check_pyproject_toml and detects hit" {
@@ -740,6 +880,23 @@ write_cargo_toml() {
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }
 
+@test "check_gemfile: matches exact package names containing regex metacharacters" {
+    local f; f="$(mktemp)"
+    write_gemfile "$f" "zope.interface" "6.1"
+    check_gemfile "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "zope.interface@6.1" "$pkg_hits"
+}
+
+@test "check_gemfile: does not treat regex metacharacters in package names as wildcards" {
+    local f; f="$(mktemp)"
+    write_gemfile "$f" "zopexinterface" "6.1"
+    check_gemfile "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
+}
+
 @test "check_manifests: routes Gemfile to check_gemfile and detects hit" {
     local f; f="$(mktemp)"
     write_gemfile "$f" "rails" "7.0.0"
@@ -780,6 +937,23 @@ write_cargo_toml() {
     local f; f="$(mktemp)"
     printf '{"require": {"vendor/package": "^1.0.0"}}\n' > "$f"
     check_composer_json "$f" "$pkg_hits" "vendor/package|1.0.0"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 0 ]
+}
+
+@test "check_composer_json: matches exact package names containing regex metacharacters" {
+    local f; f="$(mktemp)"
+    write_composer_json "$f" "zope.interface" "6.1"
+    check_composer_json "$f" "$pkg_hits" "zope.interface|6.1"
+    rm -f "$f"
+    [ "$(wc -l < "$pkg_hits")" -eq 1 ]
+    grep -q "zope.interface@6.1" "$pkg_hits"
+}
+
+@test "check_composer_json: does not treat regex metacharacters in package names as wildcards" {
+    local f; f="$(mktemp)"
+    write_composer_json "$f" "zopexinterface" "6.1"
+    check_composer_json "$f" "$pkg_hits" "zope.interface|6.1"
     rm -f "$f"
     [ "$(wc -l < "$pkg_hits")" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- replace non-portable package-scan parsing with portable awk-based helpers for package-lock, Pipfile.lock, composer.lock, and postinstall inspection
- harden manifest matching so package names with regex metacharacters are treated literally across Pipfile, pyproject.toml, Gemfile, and composer.json
- add regression coverage for multiline JSON shapes, escaped postinstall strings, duplicate Cargo.lock entries, and exact-name matching edge cases

This covers off a key finding from the portability contract check run in #41 (specifically, platform-dependent `grep -A` usage) as well as fixing a number of parsing issues that were detected by extending the test coverage.

## Verification
- bats tests/package_check.bats
- bats tests/scanner.bats
- shellcheck -x src/package_check.sh